### PR TITLE
✨Fix api/v1/users/condition end point can not handle filter with Chinese

### DIFF
--- a/cmd/sponge/commands/generate/template.go
+++ b/cmd/sponge/commands/generate/template.go
@@ -488,7 +488,7 @@ database:
   # mysql settings
   mysql:
     # dsn format,  <username>:<password>@(<hostname>:<port>)/<db>?[k=v& ......]
-    dsn: "root:123456@(192.168.3.37:3306)/account?parseTime=true&loc=Local&charset=utf8,utf8mb4"
+    dsn: "root:123456@(192.168.3.37:3306)/account?parseTime=true&loc=Local&charset=utf8mb4&collation=utf8mb4_general_ci"
     enableLog: true         # whether to turn on printing of all logs
     maxIdleConns: 10        # set the maximum number of connections in the idle connection pool
     maxOpenConns: 100       # set the maximum number of open database connections
@@ -535,7 +535,7 @@ database:
   # mysql settings
   mysql:
     # dsn format,  <username>:<password>@(<hostname>:<port>)/<db>?[k=v& ......]
-    dsn: "root:123456@(192.168.3.37:3306)/account?parseTime=true&loc=Local&charset=utf8,utf8mb4"
+    dsn: "root:123456@(192.168.3.37:3306)/account?parseTime=true&loc=Local&charset=utf8mb4&collation=utf8mb4_general_ci"
     enableLog: true         # whether to turn on printing of all logs
     maxIdleConns: 10        # set the maximum number of connections in the idle connection pool
     maxOpenConns: 100       # set the maximum number of open database connections

--- a/configs/serverNameExample.yml
+++ b/configs/serverNameExample.yml
@@ -86,7 +86,7 @@ database:
   # mysql settings
   mysql:
     # dsn format,  <username>:<password>@(<hostname>:<port>)/<db>?[k=v& ......]
-    dsn: "root:123456@(192.168.3.37:3306)/account?parseTime=true&loc=Local&charset=utf8,utf8mb4"
+    dsn: "root:123456@(192.168.3.37:3306)/account?parseTime=true&loc=Local&charset=utf8mb4&collation=utf8mb4_general_ci"
     enableLog: true         # whether to turn on printing of all logs
     maxIdleConns: 10        # set the maximum number of connections in the idle connection pool
     maxOpenConns: 100       # set the maximum number of open database connections

--- a/pkg/conf/test.yml
+++ b/pkg/conf/test.yml
@@ -10,7 +10,7 @@ database:
 # mysql settings
   mysql:
     # dsn format, <user>:<pass>@(127.0.0.1:3306)/<db>?[k=v& ......]
-    dsn: "root:123456@(192.168.3.37:3306)/account?parseTime=true&loc=Local&charset=utf8,utf8mb4"
+    dsn: "root:123456@(192.168.3.37:3306)/account?parseTime=true&loc=Local&charset=utf8mb4&collation=utf8mb4_general_ci"
 
 # redis settings
 redis:

--- a/pkg/sgorm/README.md
+++ b/pkg/sgorm/README.md
@@ -13,7 +13,7 @@ Support `mysql`, `postgresql`, `sqlite`.
 ```go
     import "github.com/go-dev-frame/sponge/pkg/sgorm/mysql"
 
-    var dsn = "root:123456@(127.0.0.1:3306)/test?charset=utf8mb4&parseTime=True&loc=Local"
+    var dsn = "root:123456@(127.0.0.1:3306)/test?charset=utf8mb4&collation=utf8mb4_general_ci&parseTime=True&loc=Local"
 
     // case 1: connect to the database using the default settings
     db, err := mysql.Init(dsn)

--- a/pkg/sgorm/mysql/mysql.go
+++ b/pkg/sgorm/mysql/mysql.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/go-dev-frame/sponge/pkg/sgorm/dbclose"
 	"github.com/go-dev-frame/sponge/pkg/sgorm/glog"
+	"github.com/go-dev-frame/sponge/pkg/utils"
 )
 
 // Init mysql
@@ -35,7 +36,7 @@ func Init(dsn string, opts ...Option) (*gorm.DB, error) {
 	if err != nil {
 		return nil, err
 	}
-	db.Set("gorm:table_options", "CHARSET=utf8mb4") // automatic appending of table suffixes when creating tables
+	db.Set("gorm:table_options", "CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci") // automatic appending of table suffixes when creating tables
 
 	// register trace plugin
 	if o.enableTrace {
@@ -108,14 +109,14 @@ func rwSeparationPlugin(o *options) gorm.Plugin {
 	slaves := []gorm.Dialector{}
 	for _, dsn := range o.slavesDsn {
 		slaves = append(slaves, mysqlDriver.New(mysqlDriver.Config{
-			DSN: dsn,
+			DSN: utils.AdaptiveMysqlDsn(dsn),
 		}))
 	}
 
 	masters := []gorm.Dialector{}
 	for _, dsn := range o.mastersDsn {
 		masters = append(masters, mysqlDriver.New(mysqlDriver.Config{
-			DSN: dsn,
+			DSN: utils.AdaptiveMysqlDsn(dsn),
 		}))
 	}
 

--- a/pkg/sgorm/query/query_condition.go
+++ b/pkg/sgorm/query/query_condition.go
@@ -145,12 +145,13 @@ func (c *Column) checkExp() (string, error) {
 			if !ok1 {
 				return symbol, fmt.Errorf("invalid value type '%s'", c.Value)
 			}
-			l := len(val)
-			if l > 2 {
-				val2 := val[1 : l-1]
-				val2 = strings.ReplaceAll(val2, "%", "\\%")
-				val2 = strings.ReplaceAll(val2, "_", "\\_")
-				val = string(val[0]) + val2 + string(val[l-1])
+			// Use rune-safe slicing to preserve multi-byte characters
+			r := []rune(val)
+			if len(r) > 2 {
+				middle := string(r[1 : len(r)-1])
+				middle = strings.ReplaceAll(middle, "%", "\\%")
+				middle = strings.ReplaceAll(middle, "_", "\\_")
+				val = string(r[0]) + middle + string(r[len(r)-1])
 			}
 			if strings.HasPrefix(val, "%") ||
 				strings.HasPrefix(val, "_") ||

--- a/pkg/utils/dsn.go
+++ b/pkg/utils/dsn.go
@@ -11,107 +11,119 @@ func AdaptiveMysqlDsn(dsn string) string {
 	// remove optional scheme prefix
 	dsn = strings.ReplaceAll(dsn, "mysql://", "")
 
-	// ensure a valid network/address section for go-sql-driver/mysql
-	// Expected forms:
-	//   user:pass@tcp(127.0.0.1:3306)/db
-	//   user:pass@unix(/path/mysql.sock)/db
-	// If it's like '@(127.0.0.1:3306)' → add 'tcp'
-	// If it's like '@127.0.0.1:3306' → wrap to '@tcp(127.0.0.1:3306)'
-	at := strings.Index(dsn, "@")
-	if at != -1 {
-		afterAt := dsn[at+1:]
-		slashIdx := strings.Index(afterAt, "/")
-		if slashIdx != -1 {
-			addrPart := afterAt[:slashIdx]
-			// If empty addrPart, nothing to fix
-			if addrPart != "" {
-				if strings.HasPrefix(addrPart, "(") {
-					// missing protocol
-					dsn = strings.Replace(dsn, "@(", "@tcp(", 1)
-				} else if !(strings.HasPrefix(addrPart, "tcp(") || strings.HasPrefix(addrPart, "unix(")) {
-					// no parentheses and no protocol → wrap with tcp()
-					dsn = strings.Replace(dsn, "@"+addrPart, "@tcp("+addrPart+")", 1)
-				}
-			}
-		}
-	}
+	dsn = ensureNetworkAddress(dsn)
+	return ensureCharsetAndCollation(dsn)
+}
 
-	// ensure the connection prefers utf8mb4 to avoid collation mismatch
-	// issues with MySQL 8 (e.g. mixing utf8mb3_general_ci and utf8mb4_0900_ai_ci).
-	qIdx := strings.Index(dsn, "?")
-	if qIdx == -1 {
-		// no query string → add charset parameter
-		return dsn + "?charset=utf8mb4"
-	}
+// helper: ensure network/address section is valid for go-sql-driver/mysql
+func ensureNetworkAddress(dsn string) string {
+    at := strings.Index(dsn, "@")
+    if at == -1 {
+        return dsn
+    }
 
-	prefix := dsn[:qIdx]
-	queryStr := dsn[qIdx+1:]
-	parts := strings.Split(queryStr, "&")
+    afterAt := dsn[at+1:]
+    slashIdx := strings.Index(afterAt, "/")
+    if slashIdx == -1 {
+        return dsn
+    }
 
-	hasCharset := false
-	hasCollation := false
-	for i, p := range parts {
-		if strings.HasPrefix(p, "charset=") {
-			hasCharset = true
-			val := strings.TrimPrefix(p, "charset=")
-			// split by comma and de-duplicate while ensuring utf8mb4 comes first if present/added
-			charsets := []string{}
-			for _, cs := range strings.Split(val, ",") {
-				cs = strings.TrimSpace(cs)
-				if cs == "" {
-					continue
-				}
-				// skip duplicates
-				dup := false
-				for _, existing := range charsets {
-					if strings.EqualFold(existing, cs) {
-						dup = true
-						break
-					}
-				}
-				if !dup {
-					charsets = append(charsets, cs)
-				}
-			}
+    addrPart := afterAt[:slashIdx]
+    if addrPart == "" {
+        return dsn
+    }
 
-			// ensure utf8mb4 is present and at the first position
-			containsUtf8mb4 := false
-			for _, cs := range charsets {
-				if strings.EqualFold(cs, "utf8mb4") {
-					containsUtf8mb4 = true
-					break
-				}
-			}
-			if !containsUtf8mb4 {
-				charsets = append([]string{"utf8mb4"}, charsets...)
-			} else if len(charsets) > 0 && !strings.EqualFold(charsets[0], "utf8mb4") {
-				// move utf8mb4 to front
-				newOrder := []string{"utf8mb4"}
-				for _, cs := range charsets {
-					if !strings.EqualFold(cs, "utf8mb4") {
-						newOrder = append(newOrder, cs)
-					}
-				}
-				charsets = newOrder
-			}
+    if strings.HasPrefix(addrPart, "(") {
+        // missing protocol, add tcp
+        return strings.Replace(dsn, "@(", "@tcp(", 1)
+    }
 
-			parts[i] = "charset=" + strings.Join(charsets, ",")
-			break
-		}
-		if strings.HasPrefix(p, "collation=") {
-			hasCollation = true
-		}
-	}
+    if strings.HasPrefix(addrPart, "tcp(") || strings.HasPrefix(addrPart, "unix(") {
+        return dsn
+    }
 
-	if !hasCharset {
-		parts = append(parts, "charset=utf8mb4")
-	}
-	if !hasCollation {
-		// default to a broadly compatible utf8mb4 collation
-		parts = append(parts, "collation=utf8mb4_general_ci")
-	}
+    // no parentheses and no protocol → wrap with tcp()
+    return strings.Replace(dsn, "@"+addrPart, "@tcp("+addrPart+")", 1)
+}
 
-	return prefix + "?" + strings.Join(parts, "&")
+// helper: ensure charset utf8mb4 and a reasonable collation are present
+func ensureCharsetAndCollation(dsn string) string {
+    qIdx := strings.Index(dsn, "?")
+    if qIdx == -1 {
+        return dsn + "?charset=utf8mb4"
+    }
+
+    prefix := dsn[:qIdx]
+    queryStr := dsn[qIdx+1:]
+    parts := strings.Split(queryStr, "&")
+
+    hasCharset := false
+    hasCollation := false
+    for i, p := range parts {
+        if strings.HasPrefix(p, "charset=") {
+            hasCharset = true
+            parts[i] = "charset=" + normalizeCharsets(strings.TrimPrefix(p, "charset="))
+            break
+        }
+        if strings.HasPrefix(p, "collation=") {
+            hasCollation = true
+        }
+    }
+
+    if !hasCharset {
+        parts = append(parts, "charset=utf8mb4")
+    }
+    if !hasCollation {
+        parts = append(parts, "collation=utf8mb4_general_ci")
+    }
+
+    return prefix + "?" + strings.Join(parts, "&")
+}
+
+// normalizeCharsets deduplicates a comma-separated charset list and ensures utf8mb4 is first
+func normalizeCharsets(val string) string {
+    pieces := strings.Split(val, ",")
+    seen := map[string]bool{}
+    ordered := []string{}
+    for _, cs := range pieces {
+        cs = strings.TrimSpace(cs)
+        if cs == "" {
+            continue
+        }
+        lower := strings.ToLower(cs)
+        if seen[lower] {
+            continue
+        }
+        seen[lower] = true
+        ordered = append(ordered, cs)
+    }
+
+    // ensure utf8mb4 is present and at the front (case-insensitive)
+    found := -1
+    for i, cs := range ordered {
+        if strings.EqualFold(cs, "utf8mb4") {
+            found = i
+            break
+        }
+    }
+    if found == -1 {
+        ordered = append([]string{"utf8mb4"}, ordered...)
+    } else if found != 0 {
+        // move to front
+        front := []string{"utf8mb4"}
+        for i, cs := range ordered {
+            if i == found {
+                continue
+            }
+            if strings.EqualFold(cs, "utf8mb4") {
+                continue
+            }
+            front = append(front, cs)
+        }
+        ordered = front
+    }
+
+    return strings.Join(ordered, ",")
 }
 
 // AdaptivePostgresqlDsn convert postgres dsn to kv string

--- a/pkg/utils/dsn.go
+++ b/pkg/utils/dsn.go
@@ -8,7 +8,110 @@ import (
 
 // AdaptiveMysqlDsn adaptation of various mysql format dsn address
 func AdaptiveMysqlDsn(dsn string) string {
-	return strings.ReplaceAll(dsn, "mysql://", "")
+	// remove optional scheme prefix
+	dsn = strings.ReplaceAll(dsn, "mysql://", "")
+
+	// ensure a valid network/address section for go-sql-driver/mysql
+	// Expected forms:
+	//   user:pass@tcp(127.0.0.1:3306)/db
+	//   user:pass@unix(/path/mysql.sock)/db
+	// If it's like '@(127.0.0.1:3306)' → add 'tcp'
+	// If it's like '@127.0.0.1:3306' → wrap to '@tcp(127.0.0.1:3306)'
+	at := strings.Index(dsn, "@")
+	if at != -1 {
+		afterAt := dsn[at+1:]
+		slashIdx := strings.Index(afterAt, "/")
+		if slashIdx != -1 {
+			addrPart := afterAt[:slashIdx]
+			// If empty addrPart, nothing to fix
+			if addrPart != "" {
+				if strings.HasPrefix(addrPart, "(") {
+					// missing protocol
+					dsn = strings.Replace(dsn, "@(", "@tcp(", 1)
+				} else if !(strings.HasPrefix(addrPart, "tcp(") || strings.HasPrefix(addrPart, "unix(")) {
+					// no parentheses and no protocol → wrap with tcp()
+					dsn = strings.Replace(dsn, "@"+addrPart, "@tcp("+addrPart+")", 1)
+				}
+			}
+		}
+	}
+
+	// ensure the connection prefers utf8mb4 to avoid collation mismatch
+	// issues with MySQL 8 (e.g. mixing utf8mb3_general_ci and utf8mb4_0900_ai_ci).
+	qIdx := strings.Index(dsn, "?")
+	if qIdx == -1 {
+		// no query string → add charset parameter
+		return dsn + "?charset=utf8mb4"
+	}
+
+	prefix := dsn[:qIdx]
+	queryStr := dsn[qIdx+1:]
+	parts := strings.Split(queryStr, "&")
+
+	hasCharset := false
+	hasCollation := false
+	for i, p := range parts {
+		if strings.HasPrefix(p, "charset=") {
+			hasCharset = true
+			val := strings.TrimPrefix(p, "charset=")
+			// split by comma and de-duplicate while ensuring utf8mb4 comes first if present/added
+			charsets := []string{}
+			for _, cs := range strings.Split(val, ",") {
+				cs = strings.TrimSpace(cs)
+				if cs == "" {
+					continue
+				}
+				// skip duplicates
+				dup := false
+				for _, existing := range charsets {
+					if strings.EqualFold(existing, cs) {
+						dup = true
+						break
+					}
+				}
+				if !dup {
+					charsets = append(charsets, cs)
+				}
+			}
+
+			// ensure utf8mb4 is present and at the first position
+			containsUtf8mb4 := false
+			for _, cs := range charsets {
+				if strings.EqualFold(cs, "utf8mb4") {
+					containsUtf8mb4 = true
+					break
+				}
+			}
+			if !containsUtf8mb4 {
+				charsets = append([]string{"utf8mb4"}, charsets...)
+			} else if len(charsets) > 0 && !strings.EqualFold(charsets[0], "utf8mb4") {
+				// move utf8mb4 to front
+				newOrder := []string{"utf8mb4"}
+				for _, cs := range charsets {
+					if !strings.EqualFold(cs, "utf8mb4") {
+						newOrder = append(newOrder, cs)
+					}
+				}
+				charsets = newOrder
+			}
+
+			parts[i] = "charset=" + strings.Join(charsets, ",")
+			break
+		}
+		if strings.HasPrefix(p, "collation=") {
+			hasCollation = true
+		}
+	}
+
+	if !hasCharset {
+		parts = append(parts, "charset=utf8mb4")
+	}
+	if !hasCollation {
+		// default to a broadly compatible utf8mb4 collation
+		parts = append(parts, "collation=utf8mb4_general_ci")
+	}
+
+	return prefix + "?" + strings.Join(parts, "&")
 }
 
 // AdaptivePostgresqlDsn convert postgres dsn to kv string


### PR DESCRIPTION
### GPT 5 prompt

I guess due to chinese_name is utf8 input cause above error, can you propose a fix in sponge framework?

### example payload

```bash
## Get a users by custom condition
# Returns a single users that matches the specified filter conditions.
curl -X "POST" "/api/v1/users/condition" \
     -H 'Accept: *' \
     -H 'Authorization: Bearer' \
     -H 'Content-Type: application/json; charset=utf-8' \
     -d $'{
  "columns": [
    {
      "name": "chinese_name",
      "exp": "like",
      "value": "过%"
    }
  ]
}'
```



### error log

```txt
2025-09-03 09:00:54.318	INFO	middleware/logging.go:230	>>>>	{"code": 200, "method": "POST", "url": "/api/v1/users/condition", "time_us": 4108, "size": 1362, "body": "{\"code\":0,\"msg\":\"ok\",\"data\":{\"users\":{\"id\":1,\"email\":\"guochunzhong@thape.com.cn\",\"encryptedPassword\":\"$2a$11$pc3izhrvG9kYisahCXTavuaOWKafPEUsXpeAXCUDkgUADao7lIZpi\",\"resetPasswordToken\":\"\",\"resetPasswordSentAt\":null,\"rememberCreatedAt\":\"2025-04-15T07:20:07+08:00\",\"signInCount\":17845,\"currentS ...... ", "request_id": "K1KyxAQ43T"}
2025-09-03 09:01:11.201	INFO	middleware/logging.go:199	<<<<	{"method": "POST", "url": "/api/v1/users/condition", "size": 68, "body": "{\"columns\":[{\"name\":\"chinese_name\",\"exp\":\"like\",\"value\":\"\\u8fc7%\"}]}", "request_id": "Erq8Ap6sdv"}
2025-09-03 09:01:11.201	WARN	glog/glog.go:94	Gorm msg	{"error": "Error 3988 (HY000): Conversion from collation utf8mb3_general_ci into utf8mb4_0900_ai_ci impossible for parameter", "sql": "SELECT * FROM `users` WHERE chinese_name LIKE 'è\ufffd\ufffd%' ORDER BY `users`.`id` LIMIT 1", "rows": 0, "ms": 0.473583, "file_line": "dao/users.go:339", "request_id": "Erq8Ap6sdv"}
2025-09-03 09:01:11.201	ERROR	handler/users.go:307	GetByCondition error	{"error": "Error 3988 (HY000): Conversion from collation utf8mb3_general_ci into utf8mb4_0900_ai_ci impossible for parameter", "form": {"columns":[{"name":"chinese_name","exp":"like","value":"过%","logic":""}]}, "request_id": "Erq8Ap6sdv"}
test-user-server/internal/handler.(*usersHandler).GetByCondition
	/Users/guochunzhong/git/user_server-web-http/internal/handler/users.go:307
github.com/gin-gonic/gin.(*Context).Next
	/Users/guochunzhong/go/pkg/mod/github.com/gin-gonic/gin@v1.10.1/context.go:185
github.com/go-dev-frame/sponge/pkg/gin/middleware/metrics.Metrics.func1
	/Users/guochunzhong/git/oss/sponge/pkg/gin/middleware/metrics/metrics.go:121
github.com/gin-gonic/gin.(*Context).Next
	/Users/guochunzhong/go/pkg/mod/github.com/gin-gonic/gin@v1.10.1/context.go:185
github.com/go-dev-frame/sponge/pkg/gin/middleware.Logging.func1
	/Users/guochunzhong/git/oss/sponge/pkg/gin/middleware/logging.go:214
github.com/gin-gonic/gin.(*Context).Next
	/Users/guochunzhong/go/pkg/mod/github.com/gin-gonic/gin@v1.10.1/context.go:185
github.com/go-dev-frame/sponge/pkg/gin/middleware.RequestID.func1
	/Users/guochunzhong/git/oss/sponge/pkg/gin/middleware/requstid.go:102
github.com/gin-gonic/gin.(*Context).Next
	/Users/guochunzhong/go/pkg/mod/github.com/gin-gonic/gin@v1.10.1/context.go:185
github.com/gin-gonic/gin.CustomRecoveryWithWriter.func1
	/Users/guochunzhong/go/pkg/mod/github.com/gin-gonic/gin@v1.10.1/recovery.go:102
github.com/gin-gonic/gin.(*Context).Next
	/Users/guochunzhong/go/pkg/mod/github.com/gin-gonic/gin@v1.10.1/context.go:185
github.com/gin-gonic/gin.(*Engine).handleHTTPRequest
	/Users/guochunzhong/go/pkg/mod/github.com/gin-gonic/gin@v1.10.1/gin.go:644
github.com/gin-gonic/gin.(*Engine).ServeHTTP
	/Users/guochunzhong/go/pkg/mod/github.com/gin-gonic/gin@v1.10.1/gin.go:600
net/http.serverHandler.ServeHTTP
	/opt/homebrew/Cellar/go/1.24.6/libexec/src/net/http/server.go:3301
net/http.(*conn).serve
	/opt/homebrew/Cellar/go/1.24.6/libexec/src/net/http/server.go:2102
2025-09-03 09:01:11.202	ERROR	middleware/logging.go:228	>>>>	{"code": 500, "method": "POST", "url": "/api/v1/users/condition", "time_us": 982, "size": 53, "body": "{\"code\":500,\"msg\":\"Internal Server Error\",\"data\":{}}", "request_id": "Erq8Ap6sdv"}
```